### PR TITLE
feat: auto-update GitHub stars with GitHub Action

### DIFF
--- a/.github/workflows/update-stars.yml
+++ b/.github/workflows/update-stars.yml
@@ -1,0 +1,52 @@
+name: Update GitHub stars badges
+
+on:
+  schedule:
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'README.md'
+
+permissions:
+  contents: write
+
+jobs:
+  update-stars:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install dependencies
+        run: python -m pip install requests
+
+      - name: Update stars badges
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python scripts/update_stars.py
+
+      - name: Commit and push changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          
+          if git diff --quiet; then
+            echo "No changes to commit."
+            exit 0
+          fi
+          
+          git add README.md
+          git commit -m "chore: update GitHub stars"
+          git push

--- a/README.md
+++ b/README.md
@@ -60,16 +60,16 @@
 
 | 项目名称 | 描述 | 类型 | Stars | 链接 | Demo | Paper |
 |---|---|---|---|---|---|---|
-| AI-Scientist | 端到端自动科学发现系统，覆盖想法生成、实验、论文和同行评审 | agent | [![GitHub stars](https://img.shields.io/github/stars/SakanaAI/AI-Scientist?style=social)](https://github.com/SakanaAI/AI-Scientist) | [GitHub](https://github.com/SakanaAI/AI-Scientist) | - | [Nature 2024](https://modelscope.cn/papers/2408.06292/) |
-| AI-Scientist-v2 | 基于 agentic tree search 的自动科研系统，不依赖人类模板，面向更通用的 ML 研究探索 | agent | [![GitHub stars](https://img.shields.io/github/stars/SakanaAI/AI-Scientist-v2?style=social)](https://github.com/SakanaAI/AI-Scientist-v2) | [GitHub](https://github.com/SakanaAI/AI-Scientist-v2) | - | [arXiv 2025](https://modelscope.cn/papers/2504.08066/) |
-| EvoScientist | 多 agent AI scientist 系统，强调持久记忆、技能演化和端到端科研协作 | agent | [![GitHub stars](https://img.shields.io/github/stars/EvoScientist/EvoScientist?style=social)](https://github.com/EvoScientist/EvoScientist) | [GitHub](https://github.com/EvoScientist/EvoScientist) | [Demo](https://evoscientist.ai) | [arXiv 2025](https://modelscope.cn/papers/2603.08127/) |
-| nature-skills | 符合 nature 论文学术表达和科研绘图的 Skill | skill | [![GitHub stars](https://img.shields.io/github/stars/Yuan1z0825/nature-skills?style=social)](https://github.com/Yuan1z0825/nature-skills) | [GitHub](https://github.com/Yuan1z0825/nature-skills) · [魔搭 Skills](https://modelscope.cn/collections/stn54999/nature-skills) | - | - |
-| AutoResearchClaw | 自主、自进化的多阶段研究流水线，从研究想法推进到论文产物 | agent | [![GitHub stars](https://img.shields.io/github/stars/aiming-lab/AutoResearchClaw?style=social)](https://github.com/aiming-lab/AutoResearchClaw) | [GitHub](https://github.com/aiming-lab/AutoResearchClaw) | [Demo](https://openclaw.ai) | [arXiv 2025](https://modelscope.cn/papers/2605.22662/) |
-| autoresearch | Andrej Karpathy 的自主 ML 研究代理，在单 GPU 上自动运行实验并改进模型 | agent | [![GitHub stars](https://img.shields.io/github/stars/karpathy/autoresearch?style=social)](https://github.com/karpathy/autoresearch) | [GitHub](https://github.com/karpathy/autoresearch) | - | - |
-| Auto Claude Code Research in Sleep | 自动化 Claude Code 科研工作流项目，面向自动实验与代码执行 | skill | [![GitHub stars](https://img.shields.io/github/stars/wanshuiyin/Auto-claude-code-research-in-sleep?style=social)](https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep) | [GitHub](https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep) | - | - |
-| AgentLaboratory | 端到端的自主研究工作流程，由 LLM 驱动的专业代理支持完成从文献综述到报告撰写的全流程 | agent | [![GitHub stars](https://img.shields.io/github/stars/SamuelSchmidgall/AgentLaboratory?style=social)](https://github.com/SamuelSchmidgall/AgentLaboratory) | [GitHub](https://github.com/SamuelSchmidgall/AgentLaboratory) | - | - |
-| Aether | 基于 OpenCode 的开源项目，面向科研人员提供 web 与桌面端统一的 AI 研究工作环境 | agent/应用 | [![GitHub stars](https://img.shields.io/github/stars/Science-Discovery/Aether?style=social)](https://github.com/Science-Discovery/Aether) | [GitHub](https://github.com/Science-Discovery/Aether) | - | - |
-| EurekAgent | 环境工程驱动的自主科研系统，面向可度量任务协调 Claude Code 会话提出方案、实现代码、隔离评测并迭代优化 | agent | [![GitHub stars](https://img.shields.io/github/stars/THU-Team-Eureka/EurekAgent?style=social)](https://github.com/THU-Team-Eureka/EurekAgent) | [GitHub](https://github.com/THU-Team-Eureka/EurekAgent) | - | [arXiv 2026](https://arxiv.org/abs/2606.13662) |
+| AI-Scientist | 端到端自动科学发现系统，覆盖想法生成、实验、论文和同行评审 | agent | <!--stars:SakanaAI/AI-Scientist-->⭐ 14k<!--/stars--> | [GitHub](https://github.com/SakanaAI/AI-Scientist) | - | [Nature 2024](https://modelscope.cn/papers/2408.06292/) |
+| AI-Scientist-v2 | 基于 agentic tree search 的自动科研系统，不依赖人类模板，面向更通用的 ML 研究探索 | agent | <!--stars:SakanaAI/AI-Scientist-v2-->⭐ 6.6k<!--/stars--> | [GitHub](https://github.com/SakanaAI/AI-Scientist-v2) | - | [arXiv 2025](https://modelscope.cn/papers/2504.08066/) |
+| EvoScientist | 多 agent AI scientist 系统，强调持久记忆、技能演化和端到端科研协作 | agent | <!--stars:EvoScientist/EvoScientist-->⭐ 3.6k<!--/stars--> | [GitHub](https://github.com/EvoScientist/EvoScientist) | [Demo](https://evoscientist.ai) | [arXiv 2025](https://modelscope.cn/papers/2603.08127/) |
+| nature-skills | 符合 nature 论文学术表达和科研绘图的 Skill | skill | <!--stars:Yuan1z0825/nature-skills-->⭐ 20.6k<!--/stars--> | [GitHub](https://github.com/Yuan1z0825/nature-skills) · [魔搭 Skills](https://modelscope.cn/collections/stn54999/nature-skills) | - | - |
+| AutoResearchClaw | 自主、自进化的多阶段研究流水线，从研究想法推进到论文产物 | agent | <!--stars:aiming-lab/AutoResearchClaw-->⭐ 13.5k<!--/stars--> | [GitHub](https://github.com/aiming-lab/AutoResearchClaw) | [Demo](https://openclaw.ai) | [arXiv 2025](https://modelscope.cn/papers/2605.22662/) |
+| autoresearch | Andrej Karpathy 的自主 ML 研究代理，在单 GPU 上自动运行实验并改进模型 | agent | <!--stars:karpathy/autoresearch-->⭐ 87.2k<!--/stars--> | [GitHub](https://github.com/karpathy/autoresearch) | - | - |
+| Auto Claude Code Research in Sleep | 自动化 Claude Code 科研工作流项目，面向自动实验与代码执行 | skill | <!--stars:wanshuiyin/Auto-claude-code-research-in-sleep-->⭐ 12.2k<!--/stars--> | [GitHub](https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep) | - | - |
+| AgentLaboratory | 端到端的自主研究工作流程，由 LLM 驱动的专业代理支持完成从文献综述到报告撰写的全流程 | agent | <!--stars:SamuelSchmidgall/AgentLaboratory-->⭐ 5.7k<!--/stars--> | [GitHub](https://github.com/SamuelSchmidgall/AgentLaboratory) | - | - |
+| Aether | 基于 OpenCode 的开源项目，面向科研人员提供 web 与桌面端统一的 AI 研究工作环境 | agent/应用 | <!--stars:Science-Discovery/Aether-->⭐ 65<!--/stars--> | [GitHub](https://github.com/Science-Discovery/Aether) | - | - |
+| EurekAgent | 环境工程驱动的自主科研系统，面向可度量任务协调 Claude Code 会话提出方案、实现代码、隔离评测并迭代优化 | agent | <!--stars:THU-Team-Eureka/EurekAgent-->⭐ 54<!--/stars--> | [GitHub](https://github.com/THU-Team-Eureka/EurekAgent) | - | [arXiv 2026](https://arxiv.org/abs/2606.13662) |
 
 ---
 
@@ -87,9 +87,9 @@
 
 | 项目名称 | 描述 | 类型 | Stars | 链接 | Demo | Paper |
 |---|---|---|---|---|---|---|
-| STORM | 斯坦福开源知识整理系统，通过多视角问题生成和检索生成带引用报告 | agent | [![GitHub stars](https://img.shields.io/github/stars/stanford-oval/storm?style=social)](https://github.com/stanford-oval/storm) | [GitHub](https://github.com/stanford-oval/storm) | [Demo](https://storm.genie.stanford.edu) | [NAACL 2024](https://modelscope.cn/papers/2402.14207/) |
-| paperseek | 面向研究者的文献发现工具，支持自然语言检索、自动迭代查询、扩展候选论文 | agent/skill | [![GitHub stars](https://img.shields.io/github/stars/MingfengHong/paperseek?style=social)](https://github.com/MingfengHong/paperseek) | [GitHub](https://github.com/MingfengHong/paperseek) | [魔搭创空间](https://modelscope.cn/studios/HongMingfeng/PaperSeek) | - |
-| Lune | 通过 MCP 提供顶会 Paper 的 agentic search 能力，支持学术文献与科研最佳实践的 grounding | agent/tool | [![GitHub stars](https://img.shields.io/github/stars/RetrogradeLabs/lune-mcp-server?style=social)](https://github.com/RetrogradeLabs/lune-mcp-server) | [GitHub](https://github.com/RetrogradeLabs/lune-mcp-server) | [Demo](https://luneresearch.com) | - |
+| STORM | 斯坦福开源知识整理系统，通过多视角问题生成和检索生成带引用报告 | agent | <!--stars:stanford-oval/storm-->⭐ 28.4k<!--/stars--> | [GitHub](https://github.com/stanford-oval/storm) | [Demo](https://storm.genie.stanford.edu) | [NAACL 2024](https://modelscope.cn/papers/2402.14207/) |
+| paperseek | 面向研究者的文献发现工具，支持自然语言检索、自动迭代查询、扩展候选论文 | agent/skill | <!--stars:MingfengHong/paperseek-->⭐ 28<!--/stars--> | [GitHub](https://github.com/MingfengHong/paperseek) | [魔搭创空间](https://modelscope.cn/studios/HongMingfeng/PaperSeek) | - |
+| Lune | 通过 MCP 提供顶会 Paper 的 agentic search 能力，支持学术文献与科研最佳实践的 grounding | agent/tool | <!--stars:RetrogradeLabs/lune-mcp-server-->⭐ 2<!--/stars--> | [GitHub](https://github.com/RetrogradeLabs/lune-mcp-server) | [Demo](https://luneresearch.com) | - |
 
 ---
 
@@ -107,8 +107,8 @@
 
 | 项目名称 | 描述 | 类型 | Stars | 链接 | Demo | Paper |
 |---|---|---|---|---|---|---|
-| RD-Agent | 实现数据与模型高价值通用研发流程的自动化，让 AI 驱动数据驱动型 AI | agent | [![GitHub stars](https://img.shields.io/github/stars/microsoft/RD-Agent?style=social)](https://github.com/microsoft/RD-Agent) | [GitHub](https://github.com/microsoft/RD-Agent) | - | [arXiv 2025](https://arxiv.org/abs/2505.14738) |
-| EurekAgent | 面向可度量科研任务的实验执行环境，支持 Claude Code 会话自动实现方案、Docker 隔离评测、日志追踪和迭代优化 | agent | [![GitHub stars](https://img.shields.io/github/stars/THU-Team-Eureka/EurekAgent?style=social)](https://github.com/THU-Team-Eureka/EurekAgent) | [GitHub](https://github.com/THU-Team-Eureka/EurekAgent) | - | [arXiv 2026](https://arxiv.org/abs/2606.13662) |
+| RD-Agent | 实现数据与模型高价值通用研发流程的自动化，让 AI 驱动数据驱动型 AI | agent | <!--stars:microsoft/RD-Agent-->⭐ 13.5k<!--/stars--> | [GitHub](https://github.com/microsoft/RD-Agent) | - | [arXiv 2025](https://arxiv.org/abs/2505.14738) |
+| EurekAgent | 面向可度量科研任务的实验执行环境，支持 Claude Code 会话自动实现方案、Docker 隔离评测、日志追踪和迭代优化 | agent | <!--stars:THU-Team-Eureka/EurekAgent-->⭐ 54<!--/stars--> | [GitHub](https://github.com/THU-Team-Eureka/EurekAgent) | - | [arXiv 2026](https://arxiv.org/abs/2606.13662) |
 
 ---
 
@@ -118,7 +118,7 @@
 
 | 项目名称 | 描述 | 类型 | Stars | 链接 | Demo | Paper |
 |---|---|---|---|---|---|---|
-| PaperBanana | 多 agent 学术插图自动化生成框架，从文本描述生成出版级图表和统计图 | agent | [![GitHub stars](https://img.shields.io/github/stars/dwzhu-pku/PaperBanana?style=social)](https://github.com/dwzhu-pku/PaperBanana) | [GitHub](https://github.com/dwzhu-pku/PaperBanana) | [Demo](https://dwzhu-pku.github.io/PaperBanana/) | [arXiv 2025](https://modelscope.cn/papers/2601.23265/) |
+| PaperBanana | 多 agent 学术插图自动化生成框架，从文本描述生成出版级图表和统计图 | agent | <!--stars:dwzhu-pku/PaperBanana-->⭐ 6.6k<!--/stars--> | [GitHub](https://github.com/dwzhu-pku/PaperBanana) | [Demo](https://dwzhu-pku.github.io/PaperBanana/) | [arXiv 2025](https://modelscope.cn/papers/2601.23265/) |
 
 ---
 
@@ -128,7 +128,7 @@
 
 | 项目名称 | 描述 | 类型 | Stars | 链接 | Demo | Paper |
 |---|---|---|---|---|---|---|
-| Academic Research Skills | 覆盖学术写作、润色、投稿检查和发表流程的 Claude Code skill 套件，也覆盖文献调研 | skill | [![GitHub stars](https://img.shields.io/github/stars/Imbad0202/academic-research-skills?style=social)](https://github.com/Imbad0202/academic-research-skills) | [GitHub](https://github.com/Imbad0202/academic-research-skills) | - | - |
+| Academic Research Skills | 覆盖学术写作、润色、投稿检查和发表流程的 Claude Code skill 套件，也覆盖文献调研 | skill | <!--stars:Imbad0202/academic-research-skills-->⭐ 32.2k<!--/stars--> | [GitHub](https://github.com/Imbad0202/academic-research-skills) | - | - |
 
 ---
 
@@ -152,7 +152,7 @@
 
 | 项目名称 | 描述 | 类型 | Stars | 链接 | Demo/实践经验 | Paper |
 |---|---|---|---|---|---|---|
-| CitationClaw | 用 agent 挖掘可解释的论文影响力，适合论文发表后的引用画像和传播分析 | tool | [![GitHub stars](https://img.shields.io/github/stars/VisionXLab/CitationClaw?style=social)](https://github.com/VisionXLab/CitationClaw) | [GitHub](https://github.com/VisionXLab/CitationClaw) | [ModelScope Studio](https://modelscope.cn/studios/fork?target=VisionXLab/CitationClaw) | - |
+| CitationClaw | 用 agent 挖掘可解释的论文影响力，适合论文发表后的引用画像和传播分析 | tool | <!--stars:VisionXLab/CitationClaw-->⭐ 307<!--/stars--> | [GitHub](https://github.com/VisionXLab/CitationClaw) | [ModelScope Studio](https://modelscope.cn/studios/fork?target=VisionXLab/CitationClaw) | - |
 | ModelScope AI 超级简历 | 科研个人主页建设，用于沉淀模型、数据集、paper、demo 和学术影响力 | platform | - | [ModelScope](https://modelscope.cn/) | 示例：[VoyagerX](https://modelscope.cn/profile/VoyagerX) · [陈谐](https://modelscope.cn/profile/chenxie95) | - |
 
 ---
@@ -194,6 +194,17 @@
   - 失败案例与边界（"在 Y 场景下表现不好，原因是 Z"）
 
 **贡献方式：** 直接在对应阶段的表格末尾添加一行，在 "Demo/实践经验" 列填入链接。建议发布在 [魔搭研习社](https://modelscope.cn/learn) 并带上 tag `#vibe-research`，让同行更容易发现；如果已发布在其他平台，也欢迎直接填外链。如果你的实践横跨多个阶段，先放进最核心的那个阶段，在描述里注明"也覆盖 x 阶段"。
+
+**关于 Stars 列：**
+- Stars 数量由 GitHub Action 自动维护，PR 合并后每日自动更新
+- 首次添加项目时，在 `Stars` 列按以下格式填写：
+  ```
+  `<!--stars:OWNER/REPO-->⭐ updating<!--/stars-->`
+  ```
+  例如：
+  ```
+  | DeepScientist | 本地优先的自主研究工作室... | agent | <!--stars:ResearAI/DeepScientist-->⭐ 3.1k<!--/stars--> | [GitHub](...) | [Demo](...) | [arXiv 2025](...) |
+  ```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -60,16 +60,16 @@
 
 | 项目名称 | 描述 | 类型 | Stars | 链接 | Demo | Paper |
 |---|---|---|---|---|---|---|
-| AI-Scientist | 端到端自动科学发现系统，覆盖想法生成、实验、论文和同行评审 | agent | <!--stars:SakanaAI/AI-Scientist-->⭐ 14k<!--/stars--> | [GitHub](https://github.com/SakanaAI/AI-Scientist) | - | [Nature 2024](https://modelscope.cn/papers/2408.06292/) |
-| AI-Scientist-v2 | 基于 agentic tree search 的自动科研系统，不依赖人类模板，面向更通用的 ML 研究探索 | agent | <!--stars:SakanaAI/AI-Scientist-v2-->⭐ 6.6k<!--/stars--> | [GitHub](https://github.com/SakanaAI/AI-Scientist-v2) | - | [arXiv 2025](https://modelscope.cn/papers/2504.08066/) |
-| EvoScientist | 多 agent AI scientist 系统，强调持久记忆、技能演化和端到端科研协作 | agent | <!--stars:EvoScientist/EvoScientist-->⭐ 3.6k<!--/stars--> | [GitHub](https://github.com/EvoScientist/EvoScientist) | [Demo](https://evoscientist.ai) | [arXiv 2025](https://modelscope.cn/papers/2603.08127/) |
-| nature-skills | 符合 nature 论文学术表达和科研绘图的 Skill | skill | <!--stars:Yuan1z0825/nature-skills-->⭐ 20.6k<!--/stars--> | [GitHub](https://github.com/Yuan1z0825/nature-skills) · [魔搭 Skills](https://modelscope.cn/collections/stn54999/nature-skills) | - | - |
-| AutoResearchClaw | 自主、自进化的多阶段研究流水线，从研究想法推进到论文产物 | agent | <!--stars:aiming-lab/AutoResearchClaw-->⭐ 13.5k<!--/stars--> | [GitHub](https://github.com/aiming-lab/AutoResearchClaw) | [Demo](https://openclaw.ai) | [arXiv 2025](https://modelscope.cn/papers/2605.22662/) |
-| autoresearch | Andrej Karpathy 的自主 ML 研究代理，在单 GPU 上自动运行实验并改进模型 | agent | <!--stars:karpathy/autoresearch-->⭐ 87.2k<!--/stars--> | [GitHub](https://github.com/karpathy/autoresearch) | - | - |
-| Auto Claude Code Research in Sleep | 自动化 Claude Code 科研工作流项目，面向自动实验与代码执行 | skill | <!--stars:wanshuiyin/Auto-claude-code-research-in-sleep-->⭐ 12.2k<!--/stars--> | [GitHub](https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep) | - | - |
-| AgentLaboratory | 端到端的自主研究工作流程，由 LLM 驱动的专业代理支持完成从文献综述到报告撰写的全流程 | agent | <!--stars:SamuelSchmidgall/AgentLaboratory-->⭐ 5.7k<!--/stars--> | [GitHub](https://github.com/SamuelSchmidgall/AgentLaboratory) | - | - |
-| Aether | 基于 OpenCode 的开源项目，面向科研人员提供 web 与桌面端统一的 AI 研究工作环境 | agent/应用 | <!--stars:Science-Discovery/Aether-->⭐ 65<!--/stars--> | [GitHub](https://github.com/Science-Discovery/Aether) | - | - |
-| EurekAgent | 环境工程驱动的自主科研系统，面向可度量任务协调 Claude Code 会话提出方案、实现代码、隔离评测并迭代优化 | agent | <!--stars:THU-Team-Eureka/EurekAgent-->⭐ 54<!--/stars--> | [GitHub](https://github.com/THU-Team-Eureka/EurekAgent) | - | [arXiv 2026](https://arxiv.org/abs/2606.13662) |
+| AI-Scientist | 端到端自动科学发现系统，覆盖想法生成、实验、论文和同行评审 | agent | <!--stars:SakanaAI/AI-Scientist-->⭐&nbsp;14k<!--/stars--> | [GitHub](https://github.com/SakanaAI/AI-Scientist) | - | [Nature 2024](https://modelscope.cn/papers/2408.06292/) |
+| AI-Scientist-v2 | 基于 agentic tree search 的自动科研系统，不依赖人类模板，面向更通用的 ML 研究探索 | agent | <!--stars:SakanaAI/AI-Scientist-v2-->⭐&nbsp;6.6k<!--/stars--> | [GitHub](https://github.com/SakanaAI/AI-Scientist-v2) | - | [arXiv 2025](https://modelscope.cn/papers/2504.08066/) |
+| EvoScientist | 多 agent AI scientist 系统，强调持久记忆、技能演化和端到端科研协作 | agent | <!--stars:EvoScientist/EvoScientist-->⭐&nbsp;3.6k<!--/stars--> | [GitHub](https://github.com/EvoScientist/EvoScientist) | [Demo](https://evoscientist.ai) | [arXiv 2025](https://modelscope.cn/papers/2603.08127/) |
+| nature-skills | 符合 nature 论文学术表达和科研绘图的 Skill | skill | <!--stars:Yuan1z0825/nature-skills-->⭐&nbsp;20.6k<!--/stars--> | [GitHub](https://github.com/Yuan1z0825/nature-skills) · [魔搭 Skills](https://modelscope.cn/collections/stn54999/nature-skills) | - | - |
+| AutoResearchClaw | 自主、自进化的多阶段研究流水线，从研究想法推进到论文产物 | agent | <!--stars:aiming-lab/AutoResearchClaw-->⭐&nbsp;13.5k<!--/stars--> | [GitHub](https://github.com/aiming-lab/AutoResearchClaw) | [Demo](https://openclaw.ai) | [arXiv 2025](https://modelscope.cn/papers/2605.22662/) |
+| autoresearch | Andrej Karpathy 的自主 ML 研究代理，在单 GPU 上自动运行实验并改进模型 | agent | <!--stars:karpathy/autoresearch-->⭐&nbsp;87.2k<!--/stars--> | [GitHub](https://github.com/karpathy/autoresearch) | - | - |
+| Auto Claude Code Research in Sleep | 自动化 Claude Code 科研工作流项目，面向自动实验与代码执行 | skill | <!--stars:wanshuiyin/Auto-claude-code-research-in-sleep-->⭐&nbsp;12.2k<!--/stars--> | [GitHub](https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep) | - | - |
+| AgentLaboratory | 端到端的自主研究工作流程，由 LLM 驱动的专业代理支持完成从文献综述到报告撰写的全流程 | agent | <!--stars:SamuelSchmidgall/AgentLaboratory-->⭐&nbsp;5.7k<!--/stars--> | [GitHub](https://github.com/SamuelSchmidgall/AgentLaboratory) | - | - |
+| Aether | 基于 OpenCode 的开源项目，面向科研人员提供 web 与桌面端统一的 AI 研究工作环境 | agent/应用 | <!--stars:Science-Discovery/Aether-->⭐&nbsp;65<!--/stars--> | [GitHub](https://github.com/Science-Discovery/Aether) | - | - |
+| EurekAgent | 环境工程驱动的自主科研系统，面向可度量任务协调 Claude Code 会话提出方案、实现代码、隔离评测并迭代优化 | agent | <!--stars:THU-Team-Eureka/EurekAgent-->⭐&nbsp;54<!--/stars--> | [GitHub](https://github.com/THU-Team-Eureka/EurekAgent) | - | [arXiv 2026](https://arxiv.org/abs/2606.13662) |
 
 ---
 
@@ -87,9 +87,9 @@
 
 | 项目名称 | 描述 | 类型 | Stars | 链接 | Demo | Paper |
 |---|---|---|---|---|---|---|
-| STORM | 斯坦福开源知识整理系统，通过多视角问题生成和检索生成带引用报告 | agent | <!--stars:stanford-oval/storm-->⭐ 28.4k<!--/stars--> | [GitHub](https://github.com/stanford-oval/storm) | [Demo](https://storm.genie.stanford.edu) | [NAACL 2024](https://modelscope.cn/papers/2402.14207/) |
-| paperseek | 面向研究者的文献发现工具，支持自然语言检索、自动迭代查询、扩展候选论文 | agent/skill | <!--stars:MingfengHong/paperseek-->⭐ 28<!--/stars--> | [GitHub](https://github.com/MingfengHong/paperseek) | [魔搭创空间](https://modelscope.cn/studios/HongMingfeng/PaperSeek) | - |
-| Lune | 通过 MCP 提供顶会 Paper 的 agentic search 能力，支持学术文献与科研最佳实践的 grounding | agent/tool | <!--stars:RetrogradeLabs/lune-mcp-server-->⭐ 2<!--/stars--> | [GitHub](https://github.com/RetrogradeLabs/lune-mcp-server) | [Demo](https://luneresearch.com) | - |
+| STORM | 斯坦福开源知识整理系统，通过多视角问题生成和检索生成带引用报告 | agent | <!--stars:stanford-oval/storm-->⭐&nbsp;28.4k<!--/stars--> | [GitHub](https://github.com/stanford-oval/storm) | [Demo](https://storm.genie.stanford.edu) | [NAACL 2024](https://modelscope.cn/papers/2402.14207/) |
+| paperseek | 面向研究者的文献发现工具，支持自然语言检索、自动迭代查询、扩展候选论文 | agent/skill | <!--stars:MingfengHong/paperseek-->⭐&nbsp;28<!--/stars--> | [GitHub](https://github.com/MingfengHong/paperseek) | [魔搭创空间](https://modelscope.cn/studios/HongMingfeng/PaperSeek) | - |
+| Lune | 通过 MCP 提供顶会 Paper 的 agentic search 能力，支持学术文献与科研最佳实践的 grounding | agent/tool | <!--stars:RetrogradeLabs/lune-mcp-server-->⭐&nbsp;2<!--/stars--> | [GitHub](https://github.com/RetrogradeLabs/lune-mcp-server) | [Demo](https://luneresearch.com) | - |
 
 ---
 
@@ -107,8 +107,8 @@
 
 | 项目名称 | 描述 | 类型 | Stars | 链接 | Demo | Paper |
 |---|---|---|---|---|---|---|
-| RD-Agent | 实现数据与模型高价值通用研发流程的自动化，让 AI 驱动数据驱动型 AI | agent | <!--stars:microsoft/RD-Agent-->⭐ 13.5k<!--/stars--> | [GitHub](https://github.com/microsoft/RD-Agent) | - | [arXiv 2025](https://arxiv.org/abs/2505.14738) |
-| EurekAgent | 面向可度量科研任务的实验执行环境，支持 Claude Code 会话自动实现方案、Docker 隔离评测、日志追踪和迭代优化 | agent | <!--stars:THU-Team-Eureka/EurekAgent-->⭐ 54<!--/stars--> | [GitHub](https://github.com/THU-Team-Eureka/EurekAgent) | - | [arXiv 2026](https://arxiv.org/abs/2606.13662) |
+| RD-Agent | 实现数据与模型高价值通用研发流程的自动化，让 AI 驱动数据驱动型 AI | agent | <!--stars:microsoft/RD-Agent-->⭐&nbsp;13.5k<!--/stars--> | [GitHub](https://github.com/microsoft/RD-Agent) | - | [arXiv 2025](https://arxiv.org/abs/2505.14738) |
+| EurekAgent | 面向可度量科研任务的实验执行环境，支持 Claude Code 会话自动实现方案、Docker 隔离评测、日志追踪和迭代优化 | agent | <!--stars:THU-Team-Eureka/EurekAgent-->⭐&nbsp;54<!--/stars--> | [GitHub](https://github.com/THU-Team-Eureka/EurekAgent) | - | [arXiv 2026](https://arxiv.org/abs/2606.13662) |
 
 ---
 
@@ -118,7 +118,7 @@
 
 | 项目名称 | 描述 | 类型 | Stars | 链接 | Demo | Paper |
 |---|---|---|---|---|---|---|
-| PaperBanana | 多 agent 学术插图自动化生成框架，从文本描述生成出版级图表和统计图 | agent | <!--stars:dwzhu-pku/PaperBanana-->⭐ 6.6k<!--/stars--> | [GitHub](https://github.com/dwzhu-pku/PaperBanana) | [Demo](https://dwzhu-pku.github.io/PaperBanana/) | [arXiv 2025](https://modelscope.cn/papers/2601.23265/) |
+| PaperBanana | 多 agent 学术插图自动化生成框架，从文本描述生成出版级图表和统计图 | agent | <!--stars:dwzhu-pku/PaperBanana-->⭐&nbsp;6.6k<!--/stars--> | [GitHub](https://github.com/dwzhu-pku/PaperBanana) | [Demo](https://dwzhu-pku.github.io/PaperBanana/) | [arXiv 2025](https://modelscope.cn/papers/2601.23265/) |
 
 ---
 
@@ -128,7 +128,7 @@
 
 | 项目名称 | 描述 | 类型 | Stars | 链接 | Demo | Paper |
 |---|---|---|---|---|---|---|
-| Academic Research Skills | 覆盖学术写作、润色、投稿检查和发表流程的 Claude Code skill 套件，也覆盖文献调研 | skill | <!--stars:Imbad0202/academic-research-skills-->⭐ 32.2k<!--/stars--> | [GitHub](https://github.com/Imbad0202/academic-research-skills) | - | - |
+| Academic Research Skills | 覆盖学术写作、润色、投稿检查和发表流程的 Claude Code skill 套件，也覆盖文献调研 | skill | <!--stars:Imbad0202/academic-research-skills-->⭐&nbsp;32.2k<!--/stars--> | [GitHub](https://github.com/Imbad0202/academic-research-skills) | - | - |
 
 ---
 
@@ -152,7 +152,7 @@
 
 | 项目名称 | 描述 | 类型 | Stars | 链接 | Demo/实践经验 | Paper |
 |---|---|---|---|---|---|---|
-| CitationClaw | 用 agent 挖掘可解释的论文影响力，适合论文发表后的引用画像和传播分析 | tool | <!--stars:VisionXLab/CitationClaw-->⭐ 307<!--/stars--> | [GitHub](https://github.com/VisionXLab/CitationClaw) | [ModelScope Studio](https://modelscope.cn/studios/fork?target=VisionXLab/CitationClaw) | - |
+| CitationClaw | 用 agent 挖掘可解释的论文影响力，适合论文发表后的引用画像和传播分析 | tool | <!--stars:VisionXLab/CitationClaw-->⭐&nbsp;307<!--/stars--> | [GitHub](https://github.com/VisionXLab/CitationClaw) | [ModelScope Studio](https://modelscope.cn/studios/fork?target=VisionXLab/CitationClaw) | - |
 | ModelScope AI 超级简历 | 科研个人主页建设，用于沉淀模型、数据集、paper、demo 和学术影响力 | platform | - | [ModelScope](https://modelscope.cn/) | 示例：[VoyagerX](https://modelscope.cn/profile/VoyagerX) · [陈谐](https://modelscope.cn/profile/chenxie95) | - |
 
 ---
@@ -203,7 +203,7 @@
   ```
   例如：
   ```
-  | DeepScientist | 本地优先的自主研究工作室... | agent | <!--stars:ResearAI/DeepScientist-->⭐ 3.1k<!--/stars--> | [GitHub](...) | [Demo](...) | [arXiv 2025](...) |
+  | DeepScientist | 本地优先的自主研究工作室... | agent | <!--stars:ResearAI/DeepScientist-->⭐&nbsp;3.1k<!--/stars--> | [GitHub](...) | [Demo](...) | [arXiv 2025](...) |
   ```
 
 ---

--- a/README_en.md
+++ b/README_en.md
@@ -60,16 +60,16 @@ End-to-end systems from idea to paper. Agents spanning three or more stages go h
 
 | Project | Description | Type | Stars | Link | Demo | Paper |
 |---|---|---|---|---|---|---|
-| AI-Scientist | End-to-end automated scientific discovery: idea generation, experiments, paper writing, and peer review | agent | [![GitHub stars](https://img.shields.io/github/stars/SakanaAI/AI-Scientist?style=social)](https://github.com/SakanaAI/AI-Scientist) | [GitHub](https://github.com/SakanaAI/AI-Scientist) | - | [Nature 2024](https://modelscope.cn/papers/2408.06292/) |
-| AI-Scientist-v2 | Agentic tree search for automated research, template-free, targeting general ML exploration | agent | [![GitHub stars](https://img.shields.io/github/stars/SakanaAI/AI-Scientist-v2?style=social)](https://github.com/SakanaAI/AI-Scientist-v2) | [GitHub](https://github.com/SakanaAI/AI-Scientist-v2) | - | [arXiv 2025](https://modelscope.cn/papers/2504.08066/) |
-| EvoScientist | Multi-agent AI scientist with persistent memory, skill evolution, and end-to-end research collaboration | agent | [![GitHub stars](https://img.shields.io/github/stars/EvoScientist/EvoScientist?style=social)](https://github.com/EvoScientist/EvoScientist) | [GitHub](https://github.com/EvoScientist/EvoScientist) | [Demo](https://evoscientist.ai) | [arXiv 2025](https://modelscope.cn/papers/2603.08127/) |
-| nature-skills | Skills for Nature-grade academic writing and scientific figure creation | skill | [![GitHub stars](https://img.shields.io/github/stars/Yuan1z0825/nature-skills?style=social)](https://github.com/Yuan1z0825/nature-skills) | [GitHub](https://github.com/Yuan1z0825/nature-skills) · [ModelScope Skills](https://modelscope.cn/collections/stn54999/nature-skills) | - | - |
-| AutoResearchClaw | Autonomous, self-evolving multi-stage research pipeline from idea to paper artifacts | agent | [![GitHub stars](https://img.shields.io/github/stars/aiming-lab/AutoResearchClaw?style=social)](https://github.com/aiming-lab/AutoResearchClaw) | [GitHub](https://github.com/aiming-lab/AutoResearchClaw) | [Demo](https://openclaw.ai) | [arXiv 2025](https://modelscope.cn/papers/2605.22662/) |
-| autoresearch | Andrej Karpathy's autonomous ML research agent running experiments on a single GPU | agent | [![GitHub stars](https://img.shields.io/github/stars/karpathy/autoresearch?style=social)](https://github.com/karpathy/autoresearch) | [GitHub](https://github.com/karpathy/autoresearch) | - | - |
-| Auto Claude Code Research in Sleep | Automated Claude Code research workflow for unattended experiment execution | skill | [![GitHub stars](https://img.shields.io/github/stars/wanshuiyin/Auto-claude-code-research-in-sleep?style=social)](https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep) | [GitHub](https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep) | - | - |
-| AgentLaboratory | End-to-end autonomous research workflow with LLM-powered specialized agents for literature review through report writing | agent | [![GitHub stars](https://img.shields.io/github/stars/SamuelSchmidgall/AgentLaboratory?style=social)](https://github.com/SamuelSchmidgall/AgentLaboratory) | [GitHub](https://github.com/SamuelSchmidgall/AgentLaboratory) | - | - |
-| Aether | Open-source AI research environment with unified web & desktop experience, powered by research-focused agents and skills | agent/app | [![GitHub stars](https://img.shields.io/github/stars/Science-Discovery/Aether?style=social)](https://github.com/Science-Discovery/Aether) | [GitHub](https://github.com/Science-Discovery/Aether) | - | - |
-| EurekAgent | Environment-engineered autonomous research system for metric-driven tasks, coordinating Claude Code sessions to propose, implement, evaluate, and iterate solutions | agent | [![GitHub stars](https://img.shields.io/github/stars/THU-Team-Eureka/EurekAgent?style=social)](https://github.com/THU-Team-Eureka/EurekAgent) | [GitHub](https://github.com/THU-Team-Eureka/EurekAgent) | - | [arXiv 2026](https://arxiv.org/abs/2606.13662) |
+| AI-Scientist | End-to-end automated scientific discovery: idea generation, experiments, paper writing, and peer review | agent | <!--stars:SakanaAI/AI-Scientist-->⭐ 14k<!--/stars--> | [GitHub](https://github.com/SakanaAI/AI-Scientist) | - | [Nature 2024](https://modelscope.cn/papers/2408.06292/) |
+| AI-Scientist-v2 | Agentic tree search for automated research, template-free, targeting general ML exploration | agent | <!--stars:SakanaAI/AI-Scientist-v2-->⭐ 6.6k<!--/stars--> | [GitHub](https://github.com/SakanaAI/AI-Scientist-v2) | - | [arXiv 2025](https://modelscope.cn/papers/2504.08066/) |
+| EvoScientist | Multi-agent AI scientist with persistent memory, skill evolution, and end-to-end research collaboration | agent | <!--stars:EvoScientist/EvoScientist-->⭐ 3.6k<!--/stars--> | [GitHub](https://github.com/EvoScientist/EvoScientist) | [Demo](https://evoscientist.ai) | [arXiv 2025](https://modelscope.cn/papers/2603.08127/) |
+| nature-skills | Skills for Nature-grade academic writing and scientific figure creation | skill | <!--stars:Yuan1z0825/nature-skills-->⭐ 20.6k<!--/stars--> | [GitHub](https://github.com/Yuan1z0825/nature-skills) · [ModelScope Skills](https://modelscope.cn/collections/stn54999/nature-skills) | - | - |
+| AutoResearchClaw | Autonomous, self-evolving multi-stage research pipeline from idea to paper artifacts | agent | <!--stars:aiming-lab/AutoResearchClaw-->⭐ 13.5k<!--/stars--> | [GitHub](https://github.com/aiming-lab/AutoResearchClaw) | [Demo](https://openclaw.ai) | [arXiv 2025](https://modelscope.cn/papers/2605.22662/) |
+| autoresearch | Andrej Karpathy's autonomous ML research agent running experiments on a single GPU | agent | <!--stars:karpathy/autoresearch-->⭐ 87.2k<!--/stars--> | [GitHub](https://github.com/karpathy/autoresearch) | - | - |
+| Auto Claude Code Research in Sleep | Automated Claude Code research workflow for unattended experiment execution | skill | <!--stars:wanshuiyin/Auto-claude-code-research-in-sleep-->⭐ 12.2k<!--/stars--> | [GitHub](https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep) | - | - |
+| AgentLaboratory | End-to-end autonomous research workflow with LLM-powered specialized agents for literature review through report writing | agent | <!--stars:SamuelSchmidgall/AgentLaboratory-->⭐ 5.7k<!--/stars--> | [GitHub](https://github.com/SamuelSchmidgall/AgentLaboratory) | - | - |
+| Aether | Open-source AI research environment with unified web & desktop experience, powered by research-focused agents and skills | agent/app | <!--stars:Science-Discovery/Aether-->⭐ 65<!--/stars--> | [GitHub](https://github.com/Science-Discovery/Aether) | - | - |
+| EurekAgent | Environment-engineered autonomous research system for metric-driven tasks, coordinating Claude Code sessions to propose, implement, evaluate, and iterate solutions | agent | <!--stars:THU-Team-Eureka/EurekAgent-->⭐ 54<!--/stars--> | [GitHub](https://github.com/THU-Team-Eureka/EurekAgent) | - | [arXiv 2026](https://arxiv.org/abs/2606.13662) |
 
 ---
 
@@ -87,9 +87,9 @@ Literature search, RAG Q&A, automated survey generation, citation graph analysis
 
 | Project | Description | Type | Stars | Link | Demo | Paper |
 |---|---|---|---|---|---|---|
-| STORM | Stanford's open-source knowledge curation system generating cited reports via multi-perspective question generation | agent | [![GitHub stars](https://img.shields.io/github/stars/stanford-oval/storm?style=social)](https://github.com/stanford-oval/storm) | [GitHub](https://github.com/stanford-oval/storm) | [Demo](https://storm.genie.stanford.edu) | [NAACL 2024](https://modelscope.cn/papers/2402.14207/) |
-| paperseek | A researcher-oriented literature discovery tool supporting natural language queries with iterative search expansion | agent/skill | [![GitHub stars](https://img.shields.io/github/stars/MingfengHong/paperseek?style=social)](https://github.com/MingfengHong/paperseek) | [GitHub](https://github.com/MingfengHong/paperseek) | [paperseek.xyz](https://www.paperseek.xyz/) | - |
-| Lune | MCP server providing agentic search over top-tier papers, with grounding for both academic literature and research best practices | agent/tool | [![GitHub stars](https://img.shields.io/github/stars/RetrogradeLabs/lune-mcp-server?style=social)](https://github.com/RetrogradeLabs/lune-mcp-server) | [GitHub](https://github.com/RetrogradeLabs/lune-mcp-server) | [Demo](https://luneresearch.com) | - |
+| STORM | Stanford's open-source knowledge curation system generating cited reports via multi-perspective question generation | agent | <!--stars:stanford-oval/storm-->⭐ 28.4k<!--/stars--> | [GitHub](https://github.com/stanford-oval/storm) | [Demo](https://storm.genie.stanford.edu) | [NAACL 2024](https://modelscope.cn/papers/2402.14207/) |
+| paperseek | A researcher-oriented literature discovery tool supporting natural language queries with iterative search expansion | agent/skill | <!--stars:MingfengHong/paperseek-->⭐ 28<!--/stars--> | [GitHub](https://github.com/MingfengHong/paperseek) | [paperseek.xyz](https://www.paperseek.xyz/) | - |
+| Lune | MCP server providing agentic search over top-tier papers, with grounding for both academic literature and research best practices | agent/tool | <!--stars:RetrogradeLabs/lune-mcp-server-->⭐ 2<!--/stars--> | [GitHub](https://github.com/RetrogradeLabs/lune-mcp-server) | [Demo](https://luneresearch.com) | - |
 
 ---
 
@@ -107,8 +107,8 @@ Coding, experiment running, statistical analysis, failure analysis, robustness c
 
 | Project | Description | Type | Stars | Link | Demo | Paper |
 |---|---|---|---|---|---|---|
-| RD-Agent | Automates high-value R&D processes for data and models — letting AI drive data-driven AI | agent | [![GitHub stars](https://img.shields.io/github/stars/microsoft/RD-Agent?style=social)](https://github.com/microsoft/RD-Agent) | [GitHub](https://github.com/microsoft/RD-Agent) | - | [arXiv 2025](https://arxiv.org/abs/2505.14738) |
-| EurekAgent | Execution environment for metric-driven research tasks, supporting Claude Code sessions for implementation, Docker-isolated evaluation, logging, and iterative optimization | agent | [![GitHub stars](https://img.shields.io/github/stars/THU-Team-Eureka/EurekAgent?style=social)](https://github.com/THU-Team-Eureka/EurekAgent) | [GitHub](https://github.com/THU-Team-Eureka/EurekAgent) | - | [arXiv 2026](https://arxiv.org/abs/2606.13662) |
+| RD-Agent | Automates high-value R&D processes for data and models — letting AI drive data-driven AI | agent | <!--stars:microsoft/RD-Agent-->⭐ 13.5k<!--/stars--> | [GitHub](https://github.com/microsoft/RD-Agent) | - | [arXiv 2025](https://arxiv.org/abs/2505.14738) |
+| EurekAgent | Execution environment for metric-driven research tasks, supporting Claude Code sessions for implementation, Docker-isolated evaluation, logging, and iterative optimization | agent | <!--stars:THU-Team-Eureka/EurekAgent-->⭐ 54<!--/stars--> | [GitHub](https://github.com/THU-Team-Eureka/EurekAgent) | - | [arXiv 2026](https://arxiv.org/abs/2606.13662) |
 
 ---
 
@@ -118,7 +118,7 @@ Publication-quality figures, schematic generation, data dashboards. Slides/poste
 
 | Project | Description | Type | Stars | Link | Demo | Paper |
 |---|---|---|---|---|---|---|
-| PaperBanana | Multi-agent framework for automated academic illustration, generating publication-ready charts from text descriptions | agent | [![GitHub stars](https://img.shields.io/github/stars/dwzhu-pku/PaperBanana?style=social)](https://github.com/dwzhu-pku/PaperBanana) | [GitHub](https://github.com/dwzhu-pku/PaperBanana) | [Demo](https://dwzhu-pku.github.io/PaperBanana/) | [arXiv 2025](https://modelscope.cn/papers/2601.23265/) |
+| PaperBanana | Multi-agent framework for automated academic illustration, generating publication-ready charts from text descriptions | agent | <!--stars:dwzhu-pku/PaperBanana-->⭐ 6.6k<!--/stars--> | [GitHub](https://github.com/dwzhu-pku/PaperBanana) | [Demo](https://dwzhu-pku.github.io/PaperBanana/) | [arXiv 2025](https://modelscope.cn/papers/2601.23265/) |
 
 ---
 
@@ -128,7 +128,7 @@ Drafting, polishing, citation verification, LaTeX assistance, rebuttal, reviewin
 
 | Project | Description | Type | Stars | Link | Demo | Paper |
 |---|---|---|---|---|---|---|
-| Academic Research Skills | Claude Code skill suite covering academic writing, polishing, submission checks, and publication workflow | skill | [![GitHub stars](https://img.shields.io/github/stars/Imbad0202/academic-research-skills?style=social)](https://github.com/Imbad0202/academic-research-skills) | [GitHub](https://github.com/Imbad0202/academic-research-skills) | - | - |
+| Academic Research Skills | Claude Code skill suite covering academic writing, polishing, submission checks, and publication workflow | skill | <!--stars:Imbad0202/academic-research-skills-->⭐ 32.2k<!--/stars--> | [GitHub](https://github.com/Imbad0202/academic-research-skills) | - | - |
 
 ---
 
@@ -152,7 +152,7 @@ Slides, posters, blog posts, social media outreach, citation analysis, academic 
 
 | Project | Description | Type | Stars | Link | Demo/Practice | Paper |
 |---|---|---|---|---|---|---|
-| CitationClaw | Agent-powered explainable citation impact mining for post-publication analysis | tool | [![GitHub stars](https://img.shields.io/github/stars/VisionXLab/CitationClaw?style=social)](https://github.com/VisionXLab/CitationClaw) | [GitHub](https://github.com/VisionXLab/CitationClaw) | [ModelScope Studio](https://modelscope.cn/studios/fork?target=VisionXLab/CitationClaw) | - |
+| CitationClaw | Agent-powered explainable citation impact mining for post-publication analysis | tool | <!--stars:VisionXLab/CitationClaw-->⭐ 307<!--/stars--> | [GitHub](https://github.com/VisionXLab/CitationClaw) | [ModelScope Studio](https://modelscope.cn/studios/fork?target=VisionXLab/CitationClaw) | - |
 | ModelScope AI Super Resume | Build your research profile to showcase models, datasets, papers, demos, and academic influence | platform | - | [ModelScope](https://modelscope.cn/) | Examples: [VoyagerX](https://modelscope.cn/profile/VoyagerX) · [chenxie95](https://modelscope.cn/profile/chenxie95) | - |
 
 ---
@@ -194,6 +194,21 @@ Beyond recommending existing open-source projects, we **especially encourage** y
   - Failure cases & boundaries ("Doesn't work well in Y scenario because of Z")
 
 **How to contribute:** Add a row at the end of the relevant stage table, and fill in a link in the "Demo/Practice" column. We recommend publishing on [ModelScope Learn](https://modelscope.cn/learn) with the `#vibe-research` tag for discoverability; external links are also welcome. If your practice spans multiple stages, place it in the most core stage and note "also covers stage X" in the description.
+
+**About the Stars column:**
+- Stars are automatically maintained by GitHub Action — **just add the marker on first submission**, and they will be updated automatically
+- When adding a new project, fill the `Stars` column with:
+  ```
+  `<!--stars:OWNER/REPO-->⭐ updating<!--/stars-->`
+  ```
+  For example:
+  ```
+  | DeepScientist | Local-first autonomous research studio... | agent | <!--stars:ResearAI/DeepScientist-->⭐ 3.1k<!--/stars--> | [GitHub](...) | [Demo](...) | [arXiv 2025](...) |
+  ```
+- Update frequency:
+  - **Scheduled**: Daily at 2:00 AM (UTC)
+  - **Immediate**: Triggered right after a PR is merged to `main` if `README.md` is changed
+- If the GitHub API is temporarily unavailable, the script automatically keeps the previous star count — no blank values
 
 ---
 

--- a/README_en.md
+++ b/README_en.md
@@ -60,16 +60,16 @@ End-to-end systems from idea to paper. Agents spanning three or more stages go h
 
 | Project | Description | Type | Stars | Link | Demo | Paper |
 |---|---|---|---|---|---|---|
-| AI-Scientist | End-to-end automated scientific discovery: idea generation, experiments, paper writing, and peer review | agent | <!--stars:SakanaAI/AI-Scientist-->⭐ 14k<!--/stars--> | [GitHub](https://github.com/SakanaAI/AI-Scientist) | - | [Nature 2024](https://modelscope.cn/papers/2408.06292/) |
-| AI-Scientist-v2 | Agentic tree search for automated research, template-free, targeting general ML exploration | agent | <!--stars:SakanaAI/AI-Scientist-v2-->⭐ 6.6k<!--/stars--> | [GitHub](https://github.com/SakanaAI/AI-Scientist-v2) | - | [arXiv 2025](https://modelscope.cn/papers/2504.08066/) |
-| EvoScientist | Multi-agent AI scientist with persistent memory, skill evolution, and end-to-end research collaboration | agent | <!--stars:EvoScientist/EvoScientist-->⭐ 3.6k<!--/stars--> | [GitHub](https://github.com/EvoScientist/EvoScientist) | [Demo](https://evoscientist.ai) | [arXiv 2025](https://modelscope.cn/papers/2603.08127/) |
-| nature-skills | Skills for Nature-grade academic writing and scientific figure creation | skill | <!--stars:Yuan1z0825/nature-skills-->⭐ 20.6k<!--/stars--> | [GitHub](https://github.com/Yuan1z0825/nature-skills) · [ModelScope Skills](https://modelscope.cn/collections/stn54999/nature-skills) | - | - |
-| AutoResearchClaw | Autonomous, self-evolving multi-stage research pipeline from idea to paper artifacts | agent | <!--stars:aiming-lab/AutoResearchClaw-->⭐ 13.5k<!--/stars--> | [GitHub](https://github.com/aiming-lab/AutoResearchClaw) | [Demo](https://openclaw.ai) | [arXiv 2025](https://modelscope.cn/papers/2605.22662/) |
-| autoresearch | Andrej Karpathy's autonomous ML research agent running experiments on a single GPU | agent | <!--stars:karpathy/autoresearch-->⭐ 87.2k<!--/stars--> | [GitHub](https://github.com/karpathy/autoresearch) | - | - |
-| Auto Claude Code Research in Sleep | Automated Claude Code research workflow for unattended experiment execution | skill | <!--stars:wanshuiyin/Auto-claude-code-research-in-sleep-->⭐ 12.2k<!--/stars--> | [GitHub](https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep) | - | - |
-| AgentLaboratory | End-to-end autonomous research workflow with LLM-powered specialized agents for literature review through report writing | agent | <!--stars:SamuelSchmidgall/AgentLaboratory-->⭐ 5.7k<!--/stars--> | [GitHub](https://github.com/SamuelSchmidgall/AgentLaboratory) | - | - |
-| Aether | Open-source AI research environment with unified web & desktop experience, powered by research-focused agents and skills | agent/app | <!--stars:Science-Discovery/Aether-->⭐ 65<!--/stars--> | [GitHub](https://github.com/Science-Discovery/Aether) | - | - |
-| EurekAgent | Environment-engineered autonomous research system for metric-driven tasks, coordinating Claude Code sessions to propose, implement, evaluate, and iterate solutions | agent | <!--stars:THU-Team-Eureka/EurekAgent-->⭐ 54<!--/stars--> | [GitHub](https://github.com/THU-Team-Eureka/EurekAgent) | - | [arXiv 2026](https://arxiv.org/abs/2606.13662) |
+| AI-Scientist | End-to-end automated scientific discovery: idea generation, experiments, paper writing, and peer review | agent | <!--stars:SakanaAI/AI-Scientist-->⭐&nbsp;14k<!--/stars--> | [GitHub](https://github.com/SakanaAI/AI-Scientist) | - | [Nature 2024](https://modelscope.cn/papers/2408.06292/) |
+| AI-Scientist-v2 | Agentic tree search for automated research, template-free, targeting general ML exploration | agent | <!--stars:SakanaAI/AI-Scientist-v2-->⭐&nbsp;6.6k<!--/stars--> | [GitHub](https://github.com/SakanaAI/AI-Scientist-v2) | - | [arXiv 2025](https://modelscope.cn/papers/2504.08066/) |
+| EvoScientist | Multi-agent AI scientist with persistent memory, skill evolution, and end-to-end research collaboration | agent | <!--stars:EvoScientist/EvoScientist-->⭐&nbsp;3.6k<!--/stars--> | [GitHub](https://github.com/EvoScientist/EvoScientist) | [Demo](https://evoscientist.ai) | [arXiv 2025](https://modelscope.cn/papers/2603.08127/) |
+| nature-skills | Skills for Nature-grade academic writing and scientific figure creation | skill | <!--stars:Yuan1z0825/nature-skills-->⭐&nbsp;20.6k<!--/stars--> | [GitHub](https://github.com/Yuan1z0825/nature-skills) · [ModelScope Skills](https://modelscope.cn/collections/stn54999/nature-skills) | - | - |
+| AutoResearchClaw | Autonomous, self-evolving multi-stage research pipeline from idea to paper artifacts | agent | <!--stars:aiming-lab/AutoResearchClaw-->⭐&nbsp;13.5k<!--/stars--> | [GitHub](https://github.com/aiming-lab/AutoResearchClaw) | [Demo](https://openclaw.ai) | [arXiv 2025](https://modelscope.cn/papers/2605.22662/) |
+| autoresearch | Andrej Karpathy's autonomous ML research agent running experiments on a single GPU | agent | <!--stars:karpathy/autoresearch-->⭐&nbsp;87.2k<!--/stars--> | [GitHub](https://github.com/karpathy/autoresearch) | - | - |
+| Auto Claude Code Research in Sleep | Automated Claude Code research workflow for unattended experiment execution | skill | <!--stars:wanshuiyin/Auto-claude-code-research-in-sleep-->⭐&nbsp;12.2k<!--/stars--> | [GitHub](https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep) | - | - |
+| AgentLaboratory | End-to-end autonomous research workflow with LLM-powered specialized agents for literature review through report writing | agent | <!--stars:SamuelSchmidgall/AgentLaboratory-->⭐&nbsp;5.7k<!--/stars--> | [GitHub](https://github.com/SamuelSchmidgall/AgentLaboratory) | - | - |
+| Aether | Open-source AI research environment with unified web & desktop experience, powered by research-focused agents and skills | agent/app | <!--stars:Science-Discovery/Aether-->⭐&nbsp;65<!--/stars--> | [GitHub](https://github.com/Science-Discovery/Aether) | - | - |
+| EurekAgent | Environment-engineered autonomous research system for metric-driven tasks, coordinating Claude Code sessions to propose, implement, evaluate, and iterate solutions | agent | <!--stars:THU-Team-Eureka/EurekAgent-->⭐&nbsp;54<!--/stars--> | [GitHub](https://github.com/THU-Team-Eureka/EurekAgent) | - | [arXiv 2026](https://arxiv.org/abs/2606.13662) |
 
 ---
 
@@ -87,9 +87,9 @@ Literature search, RAG Q&A, automated survey generation, citation graph analysis
 
 | Project | Description | Type | Stars | Link | Demo | Paper |
 |---|---|---|---|---|---|---|
-| STORM | Stanford's open-source knowledge curation system generating cited reports via multi-perspective question generation | agent | <!--stars:stanford-oval/storm-->⭐ 28.4k<!--/stars--> | [GitHub](https://github.com/stanford-oval/storm) | [Demo](https://storm.genie.stanford.edu) | [NAACL 2024](https://modelscope.cn/papers/2402.14207/) |
-| paperseek | A researcher-oriented literature discovery tool supporting natural language queries with iterative search expansion | agent/skill | <!--stars:MingfengHong/paperseek-->⭐ 28<!--/stars--> | [GitHub](https://github.com/MingfengHong/paperseek) | [paperseek.xyz](https://www.paperseek.xyz/) | - |
-| Lune | MCP server providing agentic search over top-tier papers, with grounding for both academic literature and research best practices | agent/tool | <!--stars:RetrogradeLabs/lune-mcp-server-->⭐ 2<!--/stars--> | [GitHub](https://github.com/RetrogradeLabs/lune-mcp-server) | [Demo](https://luneresearch.com) | - |
+| STORM | Stanford's open-source knowledge curation system generating cited reports via multi-perspective question generation | agent | <!--stars:stanford-oval/storm-->⭐&nbsp;28.4k<!--/stars--> | [GitHub](https://github.com/stanford-oval/storm) | [Demo](https://storm.genie.stanford.edu) | [NAACL 2024](https://modelscope.cn/papers/2402.14207/) |
+| paperseek | A researcher-oriented literature discovery tool supporting natural language queries with iterative search expansion | agent/skill | <!--stars:MingfengHong/paperseek-->⭐&nbsp;28<!--/stars--> | [GitHub](https://github.com/MingfengHong/paperseek) | [paperseek.xyz](https://www.paperseek.xyz/) | - |
+| Lune | MCP server providing agentic search over top-tier papers, with grounding for both academic literature and research best practices | agent/tool | <!--stars:RetrogradeLabs/lune-mcp-server-->⭐&nbsp;2<!--/stars--> | [GitHub](https://github.com/RetrogradeLabs/lune-mcp-server) | [Demo](https://luneresearch.com) | - |
 
 ---
 
@@ -107,8 +107,8 @@ Coding, experiment running, statistical analysis, failure analysis, robustness c
 
 | Project | Description | Type | Stars | Link | Demo | Paper |
 |---|---|---|---|---|---|---|
-| RD-Agent | Automates high-value R&D processes for data and models — letting AI drive data-driven AI | agent | <!--stars:microsoft/RD-Agent-->⭐ 13.5k<!--/stars--> | [GitHub](https://github.com/microsoft/RD-Agent) | - | [arXiv 2025](https://arxiv.org/abs/2505.14738) |
-| EurekAgent | Execution environment for metric-driven research tasks, supporting Claude Code sessions for implementation, Docker-isolated evaluation, logging, and iterative optimization | agent | <!--stars:THU-Team-Eureka/EurekAgent-->⭐ 54<!--/stars--> | [GitHub](https://github.com/THU-Team-Eureka/EurekAgent) | - | [arXiv 2026](https://arxiv.org/abs/2606.13662) |
+| RD-Agent | Automates high-value R&D processes for data and models — letting AI drive data-driven AI | agent | <!--stars:microsoft/RD-Agent-->⭐&nbsp;13.5k<!--/stars--> | [GitHub](https://github.com/microsoft/RD-Agent) | - | [arXiv 2025](https://arxiv.org/abs/2505.14738) |
+| EurekAgent | Execution environment for metric-driven research tasks, supporting Claude Code sessions for implementation, Docker-isolated evaluation, logging, and iterative optimization | agent | <!--stars:THU-Team-Eureka/EurekAgent-->⭐&nbsp;54<!--/stars--> | [GitHub](https://github.com/THU-Team-Eureka/EurekAgent) | - | [arXiv 2026](https://arxiv.org/abs/2606.13662) |
 
 ---
 
@@ -118,7 +118,7 @@ Publication-quality figures, schematic generation, data dashboards. Slides/poste
 
 | Project | Description | Type | Stars | Link | Demo | Paper |
 |---|---|---|---|---|---|---|
-| PaperBanana | Multi-agent framework for automated academic illustration, generating publication-ready charts from text descriptions | agent | <!--stars:dwzhu-pku/PaperBanana-->⭐ 6.6k<!--/stars--> | [GitHub](https://github.com/dwzhu-pku/PaperBanana) | [Demo](https://dwzhu-pku.github.io/PaperBanana/) | [arXiv 2025](https://modelscope.cn/papers/2601.23265/) |
+| PaperBanana | Multi-agent framework for automated academic illustration, generating publication-ready charts from text descriptions | agent | <!--stars:dwzhu-pku/PaperBanana-->⭐&nbsp;6.6k<!--/stars--> | [GitHub](https://github.com/dwzhu-pku/PaperBanana) | [Demo](https://dwzhu-pku.github.io/PaperBanana/) | [arXiv 2025](https://modelscope.cn/papers/2601.23265/) |
 
 ---
 
@@ -128,7 +128,7 @@ Drafting, polishing, citation verification, LaTeX assistance, rebuttal, reviewin
 
 | Project | Description | Type | Stars | Link | Demo | Paper |
 |---|---|---|---|---|---|---|
-| Academic Research Skills | Claude Code skill suite covering academic writing, polishing, submission checks, and publication workflow | skill | <!--stars:Imbad0202/academic-research-skills-->⭐ 32.2k<!--/stars--> | [GitHub](https://github.com/Imbad0202/academic-research-skills) | - | - |
+| Academic Research Skills | Claude Code skill suite covering academic writing, polishing, submission checks, and publication workflow | skill | <!--stars:Imbad0202/academic-research-skills-->⭐&nbsp;32.2k<!--/stars--> | [GitHub](https://github.com/Imbad0202/academic-research-skills) | - | - |
 
 ---
 
@@ -152,7 +152,7 @@ Slides, posters, blog posts, social media outreach, citation analysis, academic 
 
 | Project | Description | Type | Stars | Link | Demo/Practice | Paper |
 |---|---|---|---|---|---|---|
-| CitationClaw | Agent-powered explainable citation impact mining for post-publication analysis | tool | <!--stars:VisionXLab/CitationClaw-->⭐ 307<!--/stars--> | [GitHub](https://github.com/VisionXLab/CitationClaw) | [ModelScope Studio](https://modelscope.cn/studios/fork?target=VisionXLab/CitationClaw) | - |
+| CitationClaw | Agent-powered explainable citation impact mining for post-publication analysis | tool | <!--stars:VisionXLab/CitationClaw-->⭐&nbsp;307<!--/stars--> | [GitHub](https://github.com/VisionXLab/CitationClaw) | [ModelScope Studio](https://modelscope.cn/studios/fork?target=VisionXLab/CitationClaw) | - |
 | ModelScope AI Super Resume | Build your research profile to showcase models, datasets, papers, demos, and academic influence | platform | - | [ModelScope](https://modelscope.cn/) | Examples: [VoyagerX](https://modelscope.cn/profile/VoyagerX) · [chenxie95](https://modelscope.cn/profile/chenxie95) | - |
 
 ---
@@ -203,7 +203,7 @@ Beyond recommending existing open-source projects, we **especially encourage** y
   ```
   For example:
   ```
-  | DeepScientist | Local-first autonomous research studio... | agent | <!--stars:ResearAI/DeepScientist-->⭐ 3.1k<!--/stars--> | [GitHub](...) | [Demo](...) | [arXiv 2025](...) |
+  | DeepScientist | Local-first autonomous research studio... | agent | <!--stars:ResearAI/DeepScientist-->⭐&nbsp;3.1k<!--/stars--> | [GitHub](...) | [Demo](...) | [arXiv 2025](...) |
   ```
 - Update frequency:
   - **Scheduled**: Daily at 2:00 AM (UTC)

--- a/scripts/update_stars.py
+++ b/scripts/update_stars.py
@@ -92,7 +92,7 @@ def fetch_stars_with_retry(repo: str, token: str | None) -> int | None:
 def build_badge(repo: str, stars: str) -> str:
     return (
         f"<!--stars:{repo}-->"
-        f"⭐ {stars}"
+        f"⭐&nbsp;{stars}"
         f"<!--/stars-->"
     )
 

--- a/scripts/update_stars.py
+++ b/scripts/update_stars.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Update static GitHub stars badges in README.md with retry and fallback."""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+import time
+from pathlib import Path
+
+import requests
+
+
+README_PATHS = [Path("README.md"), Path("README_en.md")]
+BADGE_RE = re.compile(
+    r"(?<!`)<!--stars:(?P<repo>[^>]+)-->(?P<badge>.*?)<!--/stars-->(?!`)",
+    re.DOTALL,
+)
+API_URL = "https://api.github.com/repos/{repo}"
+TIMEOUT_SECONDS = 15
+MAX_RETRIES = 3
+RETRY_DELAY_SECONDS = 5
+
+
+def format_stars(count: int) -> str:
+    if count >= 1_000_000:
+        value = f"{count / 1_000_000:.1f}".removesuffix(".0")
+        return f"{value}M"
+    if count >= 1_000:
+        value = f"{count / 1_000:.1f}".removesuffix(".0")
+        return f"{value}k"
+    return str(count)
+
+
+def parse_existing_stars(badge_text: str) -> str | None:
+    """Extract existing star count from badge text like '⭐ 87.2k'."""
+    match = re.search(r"⭐\s*([\d.]+[kM]?)", badge_text.strip())
+    return match.group(1) if match else None
+
+
+def fetch_stars(repo: str, token: str | None) -> tuple[int, int]:
+    """Fetch stars from GitHub API. Returns (stars_count, http_status).
+    Returns (0, -1) for network errors."""
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    try:
+        response = requests.get(API_URL.format(repo=repo), headers=headers, timeout=TIMEOUT_SECONDS)
+    except requests.exceptions.RequestException:
+        return 0, -1
+    
+    if not response.ok:
+        return 0, response.status_code
+    
+    data = response.json()
+    stars = data.get("stargazers_count")
+    if not isinstance(stars, int):
+        return 0, 200
+    
+    return stars, response.status_code
+
+
+def fetch_stars_with_retry(repo: str, token: str | None) -> int | None:
+    """Fetch stars with exponential backoff retry. Returns None on final failure.
+    
+    Only retries on rate limit (403), server errors (5xx), or network errors (-1).
+    Not on auth failures (401) or missing repos (404).
+    """
+    for attempt in range(MAX_RETRIES):
+        stars, status = fetch_stars(repo, token)
+        
+        if status == 200:
+            return stars
+        
+        # Don't retry on client errors (401, 404, etc.)
+        if status in (401, 404) or attempt >= MAX_RETRIES - 1:
+            print(f"{repo}: {'all attempts failed' if attempt >= MAX_RETRIES - 1 else 'failed'} (HTTP {status})", file=sys.stderr)
+            return None
+        
+        wait = RETRY_DELAY_SECONDS * (2 ** attempt)
+        print(f"{repo}: attempt {attempt + 1} failed (HTTP {status}), retrying in {wait}s...", file=sys.stderr)
+        time.sleep(wait)
+    
+    return None
+
+
+def build_badge(repo: str, stars: str) -> str:
+    return (
+        f"<!--stars:{repo}-->"
+        f"⭐ {stars}"
+        f"<!--/stars-->"
+    )
+
+
+def main() -> int:
+    token = os.environ.get("GITHUB_TOKEN")
+    any_updated = False
+    any_had_error = False
+    
+    for readme_path in README_PATHS:
+        if not readme_path.exists():
+            if readme_path.name == "README.md":
+                print(f"{readme_path} not found", file=sys.stderr)
+                return 1
+            else:
+                print(f"{readme_path} not found, skipping")
+                continue
+
+        readme = readme_path.read_text(encoding="utf-8")
+        matches = list(BADGE_RE.finditer(readme))
+
+        if not matches:
+            print(f"No stars badge markers found in {readme_path}.")
+            continue
+
+        replacements: dict[tuple[int, int], str] = {}
+        had_error = False
+        skipped_count = 0
+        updated_count = 0
+
+        for match in matches:
+            repo = match.group("repo").strip()
+            old_badge = match.group(0)
+            old_stars = parse_existing_stars(match.group("badge"))
+
+            count = fetch_stars_with_retry(repo, token)
+            if count is None:
+                # Fallback: keep existing star count if available
+                if old_stars:
+                    print(f"{repo}: failed to fetch, keeping existing value ({old_stars})")
+                    skipped_count += 1
+                    continue
+                else:
+                    print(f"{repo}: failed to fetch and no existing value to keep", file=sys.stderr)
+                    had_error = True
+                    continue
+
+            formatted = format_stars(count)
+            replacement = build_badge(repo, formatted)
+
+            if old_badge == replacement:
+                print(f"{repo}: already up to date ({formatted})")
+            else:
+                print(f"{repo}: updated to {formatted}")
+                updated_count += 1
+                replacements[match.span()] = replacement
+
+        if had_error:
+            any_had_error = True
+            print(f"\nWarning: some repos in {readme_path} failed and had no existing values to keep", file=sys.stderr)
+
+        if not replacements:
+            print(f"\n{readme_path} unchanged. ({skipped_count} repos skipped, {updated_count} updated)")
+            continue
+
+        updated = readme
+        for (start, end), replacement in reversed(replacements.items()):
+            updated = updated[:start] + replacement + updated[end:]
+
+        readme_path.write_text(updated, encoding="utf-8")
+        any_updated = True
+        print(f"\n{readme_path} updated. ({skipped_count} repos skipped, {updated_count} updated)")
+    
+    return 1 if any_had_error else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Summary

Replace dynamic shields.io GitHub stars badges with static text stars that auto-update via GitHub Action, fixing the "Unable to select next GitHub token from pool" rendering issue.

### Problem

The current README uses shields.io github/stars?style=social badges which frequently fail with:

> "Unable to select next GitHub token from pool"

This causes broken badge images in the Stars column of every project table.

### Solution
  1. Replace dynamic badges with static text stars (⭐ 14k) — no external image dependencies
  2. Add GitHub Action workflow (.github/workflows/update-stars.yml) that:
    • Scheduled: runs daily at 2:00 AM UTC
    • Push-triggered: runs immediately after PR merge to main when README.md changes
  3. Add Python script (scripts/update_stars.py) that:
    • Fetches real star counts from GitHub API
    • Retries with exponential backoff (5s → 10s → 20s) on rate limit / server errors
    • Falls back to previous star count when API is unavailable — no blank values
    • Updates both README.md and README_en.md
  
### Stars Column Format

  Contributors now add this marker (auto-updated after merge):

  <!--stars:OWNER/REPO-->⭐ updating<!--/stars-->