### PR TITLE
[codex] Add codex-paper-figure-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@
 | 项目名称 | 描述 | 类型 | Stars | 链接 | Demo | Paper |
 |---|---|---|---|---|---|---|
 | PaperBanana | 多 agent 学术插图自动化生成框架，从文本描述生成出版级图表和统计图 | agent | <!--stars:dwzhu-pku/PaperBanana-->⭐&nbsp;6.7k<!--/stars--> | [GitHub](https://github.com/dwzhu-pku/PaperBanana) | [Demo](https://dwzhu-pku.github.io/PaperBanana/) | [arXiv 2025](https://modelscope.cn/papers/2601.23265/) |
+| codex-paper-figure-skill | 面向 Codex 的论文插图生成 Skill，将论文段落、方法描述和图示想法转化为可编辑的 draw.io 学术图 | skill | <!--stars:pengqianhan/codex-paper-figure-skill-->⭐ updating<!--/stars--> | [GitHub](https://github.com/pengqianhan/codex-paper-figure-skill) | - | - |
 
 ---
 

--- a/README_en.md
+++ b/README_en.md
@@ -129,6 +129,7 @@ Publication-quality figures, schematic generation, data dashboards. Slides/poste
 | Project | Description | Type | Stars | Link | Demo | Paper |
 |---|---|---|---|---|---|---|
 | PaperBanana | Multi-agent framework for automated academic illustration, generating publication-ready charts from text descriptions | agent | <!--stars:dwzhu-pku/PaperBanana-->⭐&nbsp;6.6k<!--/stars--> | [GitHub](https://github.com/dwzhu-pku/PaperBanana) | [Demo](https://dwzhu-pku.github.io/PaperBanana/) | [arXiv 2025](https://modelscope.cn/papers/2601.23265/) |
+| codex-paper-figure-skill | Codex skill that turns paper sections, method descriptions, and figure concepts into editable draw.io academic figures | skill | <!--stars:pengqianhan/codex-paper-figure-skill-->⭐ updating<!--/stars--> | [GitHub](https://github.com/pengqianhan/codex-paper-figure-skill) | - | - |
 
 ---
 


### PR DESCRIPTION
﻿## What changed

Added `codex-paper-figure-skill` to the Stage 5 scientific visualization tables in both `README.md` and `README_en.md`.

## Why

The project provides a Codex skill for turning paper sections, method descriptions, and figure concepts into editable draw.io academic figures, so it fits the repository's scientific visualization category.

## Impact

Readers can discover an editable-first workflow for academic figure generation and refinement through draw.io / diagrams.net.

## Checks

- Confirmed the working tree only included `README.md` and `README_en.md` changes before committing.
- Verified the new rows have the expected table column count.
- Ran `git diff --check`.
