### PR TITLE
feat: add Tashan Research Skills (国科大他山)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@
 | Aether | 基于 OpenCode 的开源项目，面向科研人员提供 web 与桌面端统一的 AI 研究工作环境 | agent/应用 | <!--stars:Science-Discovery/Aether-->⭐&nbsp;67<!--/stars--> | [GitHub](https://github.com/Science-Discovery/Aether) | - | - |
 | EurekAgent | 环境工程驱动的自主科研系统，面向可度量任务协调 Claude Code 会话提出方案、实现代码、隔离评测并迭代优化 | agent | <!--stars:THU-Team-Eureka/EurekAgent-->⭐&nbsp;69<!--/stars--> | [GitHub](https://github.com/THU-Team-Eureka/EurekAgent) | - | [arXiv 2026](https://arxiv.org/abs/2606.13662) |
 | InternAgent | 面向长程自主科学发现的统一 agent 框架，支持假设生成、自动实验执行、论文复现、记忆模块和 Deep Research | agent | <!--stars:InternScience/InternAgent-->⭐&nbsp;1.4k<!--/stars--> | [GitHub](https://github.com/InternScience/InternAgent) | [Website](https://discovery.intern-ai.org.cn/home) | [arXiv 2026](https://arxiv.org/abs/2602.08990) |
+| Tashan Research Skills | 国科大他山团队自研的 16 个科研 skills，按文献证据、研究构思、成果表达、协作沉淀、工具测评五类整理，每个技能自带脚本、模板和测试 | skill | <!--stars:TashanGKD/tashan-research-skills-->⭐ updating<!--/stars--> | [GitHub](https://github.com/TashanGKD/tashan-research-skills) | - | - |
 
 ---
 

--- a/README_en.md
+++ b/README_en.md
@@ -71,6 +71,7 @@ End-to-end systems from idea to paper. Agents spanning three or more stages go h
 | Aether | Open-source AI research environment with unified web & desktop experience, powered by research-focused agents and skills | agent/app | <!--stars:Science-Discovery/Aether-->⭐&nbsp;65<!--/stars--> | [GitHub](https://github.com/Science-Discovery/Aether) | - | - |
 | EurekAgent | Environment-engineered autonomous research system for metric-driven tasks, coordinating Claude Code sessions to propose, implement, evaluate, and iterate solutions | agent | <!--stars:THU-Team-Eureka/EurekAgent-->⭐&nbsp;55<!--/stars--> | [GitHub](https://github.com/THU-Team-Eureka/EurekAgent) | - | [arXiv 2026](https://arxiv.org/abs/2606.13662) |
 | InternAgent | Unified agentic framework for long-horizon autonomous scientific discovery, covering hypothesis generation, automated experimentation, paper reproduction, memory, and Deep Research | agent | <!--stars:InternScience/InternAgent-->⭐ updating<!--/stars--> | [GitHub](https://github.com/InternScience/InternAgent) | [Website](https://discovery.intern-ai.org.cn/home) | [arXiv 2026](https://arxiv.org/abs/2602.08990) |
+| Tashan Research Skills | 16 research skills built by the Tashan team at UCAS, organized into literature evidence, ideation, expression, collaboration memory, and tool evaluation; each skill ships with its own scripts, templates, and tests | skill | <!--stars:TashanGKD/tashan-research-skills-->⭐ updating<!--/stars--> | [GitHub](https://github.com/TashanGKD/tashan-research-skills) | - | - |
 
 ---
 


### PR DESCRIPTION
## 添加条目

在「0 全流程」表格新增 **Tashan Research Skills**（中英文 README 同步添加）。

- 项目：https://github.com/TashanGKD/tashan-research-skills
- 出品：国科大他山团队（UCAS Tashan），磐石 AI4Science 生态与应用模式研究项目支持
- 内容：16 个自研科研 skills，按文献证据、研究构思、成果表达、协作沉淀、工具测评五类整理；每个技能一个目录，SKILL.md 入口，脚本、模板、测试同目录，复制进 agent 的 skills 目录即用
- 覆盖阶段：文献研究（论文检索/深度研究/论文审查）、方法设计（实验设计/数据基线）、可视化（科研绘图）、写作（学术写作/文本润色/引用合规）、传播（PPT/讲解视频），跨三个以上阶段，故放全流程节
- Stars 列已按贡献指南使用 stars 占位标记；开源协议 MIT
