### PR TITLE
Add Jacobian to experiment execution and analysis

### DIFF
--- a/README_en.md
+++ b/README_en.md
@@ -122,6 +122,7 @@ Coding, experiment running, statistical analysis, failure analysis, robustness c
 |---|---|---|---|---|---|---|
 | RD-Agent | Automates high-value R&D processes for data and models — letting AI drive data-driven AI | agent | <!--stars:microsoft/RD-Agent-->⭐&nbsp;13.5k<!--/stars--> | [GitHub](https://github.com/microsoft/RD-Agent) | - | [arXiv 2025](https://arxiv.org/abs/2505.14738) |
 | EurekAgent | Execution environment for metric-driven research tasks, supporting Claude Code sessions for implementation, Docker-isolated evaluation, logging, and iterative optimization | agent | <!--stars:THU-Team-Eureka/EurekAgent-->⭐&nbsp;55<!--/stars--> | [GitHub](https://github.com/THU-Team-Eureka/EurekAgent) | - | [arXiv 2026](https://arxiv.org/abs/2606.13662) |
+| Jacobian | MCP server, CLI, and Python library for exact computation and conjecture testing across polynomial maps, linear algebra, and graph algorithms | tool | <!--stars:morluto/jacobian-->⭐ updating<!--/stars--> | [GitHub](https://github.com/morluto/jacobian) | - | - |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds Jacobian to Stage 4, Experiment Execution & Analysis. One README line added; nothing else touched.

## What it is

Jacobian is an MCP server, CLI, and Python library for exact computation and conjecture testing across polynomial maps, linear algebra, and graph algorithms.

## Why it fits

Jacobian gives research agents a runnable tool for exact mathematical experiments and conjecture testing, matching this section’s focus on experiment execution, analysis, and reliability.

## Install

`npx -y jacobian mcp`

## License

MIT

## Validation

- `git diff --check`