### PR TITLE
添加 ScholarCopilot 学术写作与引用工具

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@
 | Academic Research Skills | 覆盖学术写作、润色、投稿检查和发表流程的 Claude Code skill 套件，也覆盖文献调研 | skill | <!--stars:Imbad0202/academic-research-skills-->⭐&nbsp;42.5k<!--/stars--> | [GitHub](https://github.com/Imbad0202/academic-research-skills) | - | - |
 | RefChecker | 学术参考文献验证工具，可检查引用真实性、元数据错误和疑似伪造引用 | tool | <!--stars:markrussinovich/refchecker-->⭐&nbsp;466<!--/stars--> | [GitHub](https://github.com/markrussinovich/refchecker) | - | - |
 | Research Paper Lifecycle Skills | 面向 Agent 的论文全生命周期 Skill 套件，覆盖文献综述、引用核验、投稿检查、审稿回复、artifact、幻灯片和海报 | skill | <!--stars:ShaishavMaisuria/research-paper-lifecycle-skills-->⭐&nbsp;29<!--/stars--> | [GitHub](https://github.com/ShaishavMaisuria/research-paper-lifecycle-skills) | [Website](https://shaishavmaisuria.github.io/research-paper-lifecycle-skills/) | - |
+| ScholarCopilot | 开源学术写作助手，联合文本续写与上下文感知的论文检索，在生成过程中建议并插入相关引用 | tool | <!--stars:TIGER-AI-Lab/ScholarCopilot-->⭐&nbsp;251<!--/stars--> | [GitHub](https://github.com/TIGER-AI-Lab/ScholarCopilot) | [Demo](https://huggingface.co/spaces/TIGER-Lab/ScholarCopilot) | [COLM 2025](https://arxiv.org/abs/2504.00824) |
 
 ---
 

--- a/README_en.md
+++ b/README_en.md
@@ -145,6 +145,7 @@ Drafting, polishing, citation verification, LaTeX assistance, rebuttal, reviewin
 | Academic Research Skills | Claude Code skill suite covering academic writing, polishing, submission checks, and publication workflow | skill | <!--stars:Imbad0202/academic-research-skills-->⭐&nbsp;32.5k<!--/stars--> | [GitHub](https://github.com/Imbad0202/academic-research-skills) | - | - |
 | RefChecker | Academic reference validation tool for checking citation existence, metadata errors, and likely fabricated references | tool | <!--stars:markrussinovich/refchecker-->⭐&nbsp;402<!--/stars--> | [GitHub](https://github.com/markrussinovich/refchecker) | - | - |
 | Research Paper Lifecycle Skills | Agent Skills package for literature review, citation verification, submission checks, rebuttals, artifacts, slides, and posters | skill | <!--stars:ShaishavMaisuria/research-paper-lifecycle-skills-->⭐ updating<!--/stars--> | [GitHub](https://github.com/ShaishavMaisuria/research-paper-lifecycle-skills) | [Website](https://shaishavmaisuria.github.io/research-paper-lifecycle-skills/) | - |
+| ScholarCopilot | Open-source academic writing assistant that jointly performs text completion and context-aware paper retrieval to suggest and insert relevant citations while drafting | tool | <!--stars:TIGER-AI-Lab/ScholarCopilot-->⭐&nbsp;251<!--/stars--> | [GitHub](https://github.com/TIGER-AI-Lab/ScholarCopilot) | [Demo](https://huggingface.co/spaces/TIGER-Lab/ScholarCopilot) | [COLM 2025](https://arxiv.org/abs/2504.00824) |
 
 ---
 


### PR DESCRIPTION
## 变更

在中英文 README 的 **论文写作、投稿与同行评审** 阶段同步加入 ScholarCopilot。该开源工具联合执行学术文本续写与上下文感知论文检索，在生成过程中建议并插入相关引用。

条目沿用项目现有的 tool / Stars / GitHub / Demo / Paper 七列表格格式，并链接官方仓库、Hugging Face Demo 和 COLM 2025 论文。默认分支与全部状态的 Issue、PR、评论和 review comment 均未发现标题、arXiv 2504.00824、官方 URL 或组织名重复；`git diff --check` 通过。

I am submitting this on behalf of repository maintainer Yuxuan Zhang.