### PR TITLE
Add STEER to Stage 5 Experiment Execution & Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@
 | RD-Agent | 实现数据与模型高价值通用研发流程的自动化，让 AI 驱动数据驱动型 AI | agent | <!--stars:microsoft/RD-Agent-->⭐&nbsp;14.6k<!--/stars--> | [GitHub](https://github.com/microsoft/RD-Agent) | - | [arXiv 2025](https://arxiv.org/abs/2505.14738) |
 | EurekAgent | 面向可度量科研任务的实验执行环境，支持 Claude Code 会话自动实现方案、Docker 隔离评测、日志追踪和迭代优化 | agent | <!--stars:THU-Team-Eureka/EurekAgent-->⭐&nbsp;83<!--/stars--> | [GitHub](https://github.com/THU-Team-Eureka/EurekAgent) | - | [arXiv 2026](https://arxiv.org/abs/2606.13662) |
 | Jacobian | 面向多项式映射、线性代数和图算法的精确计算与猜想检验工具，提供 MCP 服务器、命令行工具和 Python 库 | tool | <!--stars:morluto/jacobian-->⭐&nbsp;191<!--/stars--> | [GitHub](https://github.com/morluto/jacobian) | - | - |
+| STEER | 面向 Cursor/Claude Code 的 AI4R 实验框架：接入已有训练项目，agent 在固定任务与评分契约下改代码并训练，台账与审查门控保留证据 | agent | <!--stars:xieyulai/steer-->⭐ updating<!--/stars--> | [GitHub](https://github.com/xieyulai/steer) | - | - |
 
 ---
 

--- a/README_en.md
+++ b/README_en.md
@@ -138,6 +138,7 @@ Coding, experiment running, statistical analysis, failure analysis, robustness c
 | RD-Agent | Automates high-value R&D processes for data and models — letting AI drive data-driven AI | agent | <!--stars:microsoft/RD-Agent-->⭐&nbsp;13.5k<!--/stars--> | [GitHub](https://github.com/microsoft/RD-Agent) | - | [arXiv 2025](https://arxiv.org/abs/2505.14738) |
 | EurekAgent | Execution environment for metric-driven research tasks, supporting Claude Code sessions for implementation, Docker-isolated evaluation, logging, and iterative optimization | agent | <!--stars:THU-Team-Eureka/EurekAgent-->⭐&nbsp;55<!--/stars--> | [GitHub](https://github.com/THU-Team-Eureka/EurekAgent) | - | [arXiv 2026](https://arxiv.org/abs/2606.13662) |
 | Jacobian | MCP server, CLI, and Python library for exact computation and conjecture testing across polynomial maps, linear algebra, and graph algorithms | tool | <!--stars:morluto/jacobian-->⭐ updating<!--/stars--> | [GitHub](https://github.com/morluto/jacobian) | - | - |
+| STEER | AI4R experiment framework for Cursor/Claude Code: connect existing training projects, let agents edit and train under a fixed task/scorer contract with ledgers and audit gates | agent | <!--stars:xieyulai/steer-->⭐ updating<!--/stars--> | [GitHub](https://github.com/xieyulai/steer) | - | - |
 
 ---
 


### PR DESCRIPTION
## Summary
Add [STEER](https://github.com/xieyulai/steer) to **Stage 5 · Experiment Execution & Analysis** in both `README.md` and `README_en.md`.

STEER is an AI4R experiment framework for Cursor / Claude Code: connect an existing training project, let an agent edit code and train under a fixed task/scorer contract, with ledgers and human audit gates. It fits experiment execution rather than end-to-end paper pipelines (Stage 0).

## Checklist
- [x] Research-oriented (not a general AI assistant)
- [x] Runnable open-source code with a clear README
- [x] Actively maintained
- [x] Stars column uses `<!--stars:xieyulai/steer-->` placeholder
- [x] CN + EN tables updated
