### PR TITLE
新增 OrcaReplay：录下 agent 整次运行并离线复现

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@
 | Paper2Code | 多智能体系统，将学术论文自动转化为可运行的代码仓库 | agent | [GitHub](https://github.com/going-doer/Paper2Code) | [Quick Start](https://github.com/going-doer/Paper2Code#-quick-start) |
 | data-to-paper | 多 AI 智能体自主协作，从原始数据完成完整科研并生成可验证论文 | python 包 | [GitHub](https://github.com/Technion-Kishony-lab/data-to-paper) | - |
 | Manage AI Research Projects | 面向 Claude Code/Codex 的科研项目管理 Skill，用于创建可复现项目结构、审计 metadata 与结果追踪，并记录 AI workflow 资产 | skill | [GitHub](https://github.com/Devin-jun/Manage-AI-Research) | [README](https://github.com/Devin-jun/Manage-AI-Research/blob/main/README.zh-CN.md) |
+| OrcaReplay | 在进程外录下 AI agent 的整次运行（逐字节的模型请求与响应、每次工具调用、shell 退出码、文件改动），并可离线重放：模型回复由录像供给，不联网、不花 token，别人无需 API key 也能复现这次实验 | tool | [GitHub](https://github.com/Continuum-AI-Corp/OrcaReplay) | [集成说明](https://github.com/Continuum-AI-Corp/OrcaReplay/blob/main/docs/integrations.md) |
 
 ---
 


### PR DESCRIPTION
在 **8 📦 复现、发布与归档** 的表格里追加一行。

### 为什么放这一节

这一节已有 `Manage AI Research Projects`，它做的是「可复现的项目结构 + metadata 审计 + 记录 AI
workflow 资产」。OrcaReplay 做的是它记录的那份资产本身：把 agent 那次运行**逐字节**留下来，并且能
再跑一遍。

```console
$ orca record generic-openai -- python experiment.py
info recorded run=run_8f21c3 events=41 exit=0

$ orca replay last
info replaying exchanges=6 egress=blocked
info replay.done reused=6/6 exact=6 divergences=0 exit=0
```

第二条命令里**没有任何模型被调用**——模型回复从录像里取回，agent 自己的代码、控制流和工具调用照常
真跑一遍。对科研场景的意义很直接：审稿人或同行不需要你的 API key、不花钱、不联网，就能把你那次
「AI 跑出来的结果」原样复现；而不是只拿到一份日志和一句「当时它是这么做的」。

agent 侧不需要任何改动：`orca record` 把 agent 当子进程启动，只给它改模型服务的 origin，所以不绑定
框架——LangGraph/LangChain、CrewAI、OpenAI Agents SDK、OpenHands、Strands 以及 Claude Code / Codex /
opencode 这些 CLI 都实测过。

### 两个必须先说清楚的边界

- **`egress=blocked` 只挡模型侧出网，不是沙箱。** 录下的工具调用会真的再执行一次——那次跑过 `curl`
  或写过数据库的，重放会再动一次。
- **重放通过 ≠ 确定性结论。** 模型并没有被重新提问，是把录下的回复喂回去；「重新跑一次是不是还会
  得到同样结果」是另一个问题，重放答不了。对科研复现来说这条区别很重要，所以写在前面。

Apache-2.0，Node 20+，`npm i -g orcareplay`。我是维护者，按自荐处理即可。
